### PR TITLE
Add market wraup-up persistence and check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 # keys and token files
 api_keys.json
 tda_token.json
+
+# basic persistence
+last_tweets.json


### PR DESCRIPTION
The added code persists the time of the last market wrap-up tweet in a json file and checks if it has already been tweeted for the current day in the main run loop. 