### PR TITLE
Fix tda_api.is_market_open(client, dt) bug

### DIFF
--- a/tda_api.py
+++ b/tda_api.py
@@ -23,7 +23,12 @@ def get_market_hours(client, dt):
 
 def is_market_open(client, dt):
     try:
-        return get_market_hours(client, dt)['equity']['EQ']['isOpen']
+        response = get_market_hours(client, dt)
+        outer_equity_obj = response['equity']
+        if 'EQ' not in outer_equity_obj:
+            inner_equity_obj = outer_equity_obj['equity']
+        else:
+            inner_equity_obj = outer_equity_obj['EQ']
+        return inner_equity_obj['isOpen']
     except Exception as e:
-        print(e)
         return False


### PR DESCRIPTION
Added handling of inconsistent responses from the market hours API endpoint. 

On weekdays the following is returned
```JSON
{
  "equity": {
    "EQ": {
      "date": "2021-09-24",
      "marketType": "EQUITY",
      "isOpen": true
  }
}
```
On weekends the following is returned
```JSON
{
    "equity": {
        "equity": {
            "date": "2021-09-25",
            "marketType": "equity",
            "isOpen": false
        }
    }
}
```
A check of the first 'equity' object for the key 'EQ' was added to determine which response was returned. Only then is 'isOpen' checked. 